### PR TITLE
Require compatibility with Puppet v3.4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ rvm:
 matrix:
   allow_failures:
   - env: PUPPET_VERSION=2.7.23
-  - env: PUPPET_VERSION=3.4.2
 language: ruby
 before_script: "gem install --no-ri --no-rdoc bundler"
 script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'


### PR DESCRIPTION
This patch removes Puppet v3.4 from the matrix of allowed failures on
Travis.
