### PR TITLE
Support latest Puppet versions 4 and 5 and drop support for v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,101 +1,29 @@
 ---
 language: ruby
 
-rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-  - 2.3.1
+bundler_args: --without system_tests development
 
-env:
-  matrix:
-    - PUPPET_GEM_VERSION="~> 3.1.0"
-    - PUPPET_GEM_VERSION="~> 3.2.0"
-    - PUPPET_GEM_VERSION="~> 3.3.0"
-    - PUPPET_GEM_VERSION="~> 3.4.0"
-    - PUPPET_GEM_VERSION="~> 3.5.0"
-    - PUPPET_GEM_VERSION="~> 3.6.0"
-    - PUPPET_GEM_VERSION="~> 3.7.0"
-    - PUPPET_GEM_VERSION="~> 3.8.0"
-    - PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
-    - PUPPET_GEM_VERSION="~> 4.0.0"
-    - PUPPET_GEM_VERSION="~> 4.1.0"
-    - PUPPET_GEM_VERSION="~> 4.2.0"
-    - PUPPET_GEM_VERSION="~> 4.3.0"
-    - PUPPET_GEM_VERSION="~> 4.4.0"
-    - PUPPET_GEM_VERSION="~> 4.5.0"
-    - PUPPET_GEM_VERSION="~> 4.6.0"
-    - PUPPET_GEM_VERSION="~> 4.7.0"
-    - PUPPET_GEM_VERSION="~> 4.8.0"
-    - PUPPET_GEM_VERSION="~> 4.9.0"
-    - PUPPET_GEM_VERSION="~> 4"
+cache: bundler
+
+before_install:
+  - bundle -v
+  - rm Gemfile.lock || true
+  - gem update --system
+  - gem update bundler
+  - gem --version
+  - bundle -v
 
 sudo: false
 
-script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec'
+script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec strings:generate'
 
 matrix:
   fast_finish: true
-  exclude:
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
-    - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
-    - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.2.0"
-    - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.3.0"
-    - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.4.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.0.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.1.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.2.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.3.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.4.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.5.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.6.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.7.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.8.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.9.0"
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 4.9.0"
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 4.9.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4"
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 4"
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 4"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.2.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.3.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.4.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.5.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.6.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.7.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.8.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
+  include:
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="~> 4"
+  - rvm: 2.4.3
+    env: PUPPET_GEM_VERSION="~> 5"
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
 # Change Log
 
-## [v1.8.0](https://github.com/ghoneycutt/puppet-module-rpcbind/tree/v1.8.0)
+## [v2.0.0](https://github.com/ghoneycutt/puppet-module-rpcbind/tree/v2.0.0)
 
+[Full Changelog](https://github.com/ghoneycutt/puppet-module-rpcbind/compare/v1.8.0...v2.0.0)
+
+**Closed issues:**
+
+- Upstream issue with systemd where rpcbind\_service enable keeps changing from false to true. [\#27](https://github.com/ghoneycutt/puppet-module-rpcbind/issues/27)
+- install fails because of missing link [\#13](https://github.com/ghoneycutt/puppet-module-rpcbind/issues/13)
+
+## [v1.8.0](https://github.com/ghoneycutt/puppet-module-rpcbind/tree/v1.8.0) (2018-05-15)
 [Full Changelog](https://github.com/ghoneycutt/puppet-module-rpcbind/compare/v1.7.0...v1.8.0)
 
 **Merged pull requests:**

--- a/Gemfile
+++ b/Gemfile
@@ -1,30 +1,34 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-if puppetversion = ENV['PUPPET_GEM_VERSION']
+if puppetversion = ENV['PUPPET_GEM_VERSION'] || "~> 5.x"
   gem 'puppet', puppetversion, :require => false
 else
   gem 'puppet', :require => false
 end
 
-gem 'puppetlabs_spec_helper', '>= 1.2.0'
-gem 'facter', '>= 1.7.0'
-gem 'rspec-puppet'
-gem 'puppet-lint', '~> 2.0'
-gem 'puppet-lint-absolute_classname-check'
-gem 'puppet-lint-alias-check'
-gem 'puppet-lint-empty_string-check'
-gem 'puppet-lint-file_ensure-check'
-gem 'puppet-lint-file_source_rights-check'
-gem 'puppet-lint-leading_zero-check'
-gem 'puppet-lint-spaceship_operator_without_tag-check'
-gem 'puppet-lint-trailing_comma-check'
-gem 'puppet-lint-undef_in_function-check'
-gem 'puppet-lint-unquoted_string-check'
-gem 'puppet-lint-variable_contains_upcase'
+gem 'rake'
+gem 'metadata-json-lint',                               :require => false
+gem 'puppetlabs_spec_helper',                           :require => false
+gem 'rspec-puppet', '~> 2.0',                           :require => false
+gem 'puppet-lint', '~> 2.0',                            :require => false
+gem 'puppet-lint-absolute_classname-check',             :require => false
+gem 'puppet-lint-alias-check',                          :require => false
+gem 'puppet-lint-empty_string-check',                   :require => false
+gem 'puppet-lint-file_ensure-check',                    :require => false
+gem 'puppet-lint-file_source_rights-check',             :require => false
+gem 'puppet-lint-leading_zero-check',                   :require => false
+gem 'puppet-lint-spaceship_operator_without_tag-check', :require => false
+gem 'puppet-lint-trailing_comma-check',                 :require => false
+gem 'puppet-lint-undef_in_function-check',              :require => false
+gem 'puppet-lint-unquoted_string-check',                :require => false
+gem 'puppet-lint-variable_contains_upcase',             :require => false
 
-gem 'rspec',     '~> 2.0'   if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
-gem 'rake',      '~> 10.0'  if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
-gem 'json',      '<= 1.8'   if RUBY_VERSION < '2.0.0'
-gem 'json_pure', '<= 2.0.1' if RUBY_VERSION < '2.0.0'
-gem 'metadata-json-lint', '0.0.11'   if RUBY_VERSION < '1.9'
-gem 'metadata-json-lint'             if RUBY_VERSION >= '1.9'
+if puppetversion && puppetversion < '5.0'
+  gem 'semantic_puppet', :require => false
+end
+
+group :documentation do
+  gem 'yard',           require: false
+  gem 'redcarpet',      require: false
+  gem 'puppet-strings', require: false
+end

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2013-2016 Garrett Honeycutt <code@garretthoneycutt.com>
+Copyright (C) 2013-2018 Garrett Honeycutt <code@garretthoneycutt.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # puppet-module-rpcbind
 
-
-[![Build Status](https://api.travis-ci.org/ghoneycutt/puppet-module-rpcbind.png?branch=master)](https://travis-ci.org/ghoneycutt/puppet-module-rpcbind)
-
 Puppet module to manage rpcbind
 
 To use this module, simply `include ::rpcbind`
@@ -11,17 +8,18 @@ To use this module, simply `include ::rpcbind`
 
 # Compatibility
 
-This module is built for use with Puppet v3 (with and without the future
-parser) and Puppet v4 with Ruby versions 1.8.7, 1.9.3, 2.0.0, 2.1.0 and
-2.3.1 on the following platforms.
+This module is built for use with the latest versions of Puppet v4 and
+v5 with the ruby version packaged in the all-in-one installer. See
+`.travis.yml` for the supported matrix of versions.
 
- * Debian 6
- * EL 5
+Supports the following platforms.
+
+ * Debian 8
+ * Debian 9
  * EL 6
- * Suse 10
+ * EL 7
  * Suse 11
  * Suse 12
- * Ubuntu 12.04 LTS
  * Ubuntu 14.04 LTS
  * Ubuntu 16.04 LTS
  * Ubuntu 18.04 LTS
@@ -30,32 +28,4 @@ parser) and Puppet v4 with Ruby versions 1.8.7, 1.9.3, 2.0.0, 2.1.0 and
 
 # Parameters
 
-package_ensure
---------------
-String value for ensure attribute.
-
-- *Default*: 'installed'
-
-package_name
-------------
-Package(s) to be installed. Accepts string or array.
-
-- *Default*: 'rpcbind'
-
-service_enable
---------------
-Boolean value for enable attribute.
-
-- *Default*: true
-
-service_ensure
---------------
-String value for ensure attribute.
-
-- *Default*: 'running'
-
-service_name
-------------
-String of service name.
-
-- *Default*: based on osfamily
+[Puppet Strings documentation](http://ghoneycutt.github.io/puppet-module-rpcbind/doc/puppet_classes/rpcbind.html)

--- a/Rakefile
+++ b/Rakefile
@@ -3,17 +3,21 @@ require 'puppet-lint/tasks/puppet-lint'
 PuppetLint.configuration.send('disable_80chars')
 PuppetLint.configuration.send('disable_140chars')
 PuppetLint.configuration.relative = true
-PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+PuppetLint.configuration.ignore_paths = ['spec/**/*.pp', 'pkg/**/*.pp', 'vendor/**/*.pp']
 
 desc 'Validate manifests, templates, and ruby files'
 task :validate do
-  Dir['manifests/**/*.pp'].each do |manifest|
-    sh "puppet parser validate --noop #{manifest}"
-  end
-  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
+  Dir['spec/**/*.rb', 'lib/**/*.rb'].each do |ruby_file|
     sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
   end
-  Dir['templates/**/*.erb'].each do |template|
-    sh "erb -P -x -T '-' #{template} | ruby -c"
+  Dir['vagrant/**/*.sh'].each do |shell_script|
+    sh "bash -n #{shell_script}"
   end
 end
+
+# Puppet Strings (Documentation generation from inline comments)
+# See: https://github.com/puppetlabs/puppet-strings#rake-tasks
+require 'puppet-strings/tasks'
+
+desc 'Alias for strings:generate'
+task :doc => ['strings:generate']

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ghoneycutt-rpcbind",
-  "version": "1.8.0",
+  "version": "2.0.0",
   "author": "ghoneycutt",
   "summary": "Manage rpcbind",
   "license": "Apache-2.0",
@@ -11,42 +11,43 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 4.0.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "6"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
-        "6"
+        "6",
+        "7"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "5",
-        "6"
+        "6",
+        "7"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "5",
-        "6"
+        "6",
+        "7"
       ]
     },
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "5",
-        "6"
+        "6",
+        "7"
       ]
     },
     {
@@ -58,7 +59,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "12.04",
         "14.04",
         "16.04",
         "18.04"

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,395 +1,148 @@
 require 'spec_helper'
 describe 'rpcbind' do
 
-  describe 'with default values for parameters' do
-    context 'on unsupported osfamily' do
-      let(:facts) { { :osfamily => 'Solaris' } }
+  describe 'on unsupported platforms' do
+    unsupported_platforms.sort.each do |k,v|
+      context "with defaults params on #{k}" do
+        let(:facts) { v[:facts_hash] }
 
-      it 'should fail' do
-        expect {
-          should contain_class('rpcbind')
-        }.to raise_error(Puppet::Error,/rpcbind supports osfamilies Debian, RedHat, and Suse. Detected osfamily is <Solaris>/)
-      end
-    end
-
-    context 'on supported osfamily Debian with unsupported lsbdistid' do
-      let(:facts) do
-        { :lsbdistid => 'Unsupported',
-          :osfamily => 'Debian',
-        }
-      end
-
-      it 'should fail' do
-        expect {
-          should contain_class('rpcbind')
-        }.to raise_error(Puppet::Error,/rpcbind on osfamily Debian supports lsbdistid Debian and Ubuntu. Detected lsbdistid is <Unsupported>\./)
-      end
-    end
-
-    context 'on supported osfamily Debian with supported lsbdistid Ubuntu and unsupported lsbdistrelease' do
-      let(:facts) do
-        { :lsbdistid      => 'Ubuntu',
-          :osfamily       => 'Debian',
-          :lsbdistrelease => 'not12.04',
-        }
-      end
-
-      it 'should fail' do
-        expect {
-          should contain_class('rpcbind')
-        }.to raise_error(Puppet::Error,/rpcbind is only supported on Ubuntu 12.04, 14.04, 16.04 and 18.04. Detected lsbdistrelease is <not12.04>\./)
-      end
-    end
-
-    context 'on supported osfamily Suse with unsupported lsbmajdistrelease' do
-      let(:facts) do
-        { :lsbmajdistrelease => '9',
-          :osfamily          => 'Suse',
-        }
-      end
-
-      it 'should fail' do
-        expect {
-          should contain_class('rpcbind')
-        }.to raise_error(Puppet::Error,/rpcbind on osfamily Suse supports lsbmajdistrelease 10, 11, and 12. Detected lsbmajdistrelease is <9>\./)
+        it 'should fail' do
+          expect {
+            should contain_class('rpcbind')
+          }.to raise_error(Puppet::Error,/os\.release\.major|Unsupported osfamily detected/)
+        end
       end
     end
   end
 
-  describe 'package resource' do
-    context 'with default params on osfamily Suse 10' do
-      let(:facts) { { :osfamily => 'Suse', :lsbmajdistrelease => '10' } }
-
-      it {
-        should contain_package('portmap').with({
-          'ensure' => 'installed',
-        })
-      }
-    end
-
-    context 'with default params on osfamily Suse 11' do
-      let(:facts) { { :osfamily => 'Suse', :lsbmajdistrelease => '11' } }
-
-      it {
-        should contain_package('rpcbind').with({
-          'ensure' => 'installed',
-        })
-      }
-    end
-
-    context 'with default params on osfamily Suse 12' do
-      let(:facts) { { :osfamily => 'Suse', :lsbmajdistrelease => '12' } }
-
-      it {
-        should contain_package('rpcbind').with({
-          'ensure' => 'installed',
-        })
-      }
-    end
-
-    context 'with default params on osfamily RedHat' do
-      let(:facts) { { :osfamily => 'RedHat' } }
-
-      it {
-        should contain_package('rpcbind').with({
-          'ensure' => 'installed',
-        })
-      }
-    end
-
-    context 'with default params on Debian' do
-      let(:facts) do
-        { :lsbdistid => 'Debian',
-          :osfamily => 'Debian',
-        }
-      end
-
-      it {
-        should contain_package('rpcbind').with({
-          'ensure' => 'installed',
-        })
-      }
-    end
-
-    context 'with default params on Ubuntu 12.04' do
-      let(:facts) do
-        { :lsbdistid      => 'Ubuntu',
-          :lsbdistrelease => '12.04',
-          :osfamily       => 'Debian',
-        }
-      end
-
-      it {
-        should contain_package('rpcbind').with({
-          'ensure' => 'installed',
-        })
-      }
-    end
-
-    context 'with default params on Ubuntu 14.04' do
-      let(:facts) do
-        { :lsbdistid      => 'Ubuntu',
-          :lsbdistrelease => '14.04',
-          :osfamily       => 'Debian',
-        }
-      end
-
-      it {
-        should contain_package('rpcbind').with({
-          'ensure' => 'installed',
-        })
-      }
-    end
-
-    context 'with default params on Ubuntu 16.04' do
-      let(:facts) do
-        { :lsbdistid      => 'Ubuntu',
-          :lsbdistrelease => '16.04',
-          :osfamily       => 'Debian',
-        }
-      end
-
-      it {
-        should contain_package('rpcbind').with({
-          'ensure' => 'installed',
-        })
-      }
-    end
-
-    context 'with default params on Ubuntu 18.04' do
-      let(:facts) do
-        { :lsbdistid      => 'Ubuntu',
-          :lsbdistrelease => '18.04',
-          :osfamily       => 'Debian',
-        }
-      end
-
-      it {
-        should contain_package('rpcbind').with({
-          'ensure' => 'installed',
-        })
-      }
-    end
-
-    context 'with ensure absent' do
-      let(:facts) { { :osfamily => 'RedHat' } }
-      let(:params) { { :package_ensure => 'absent' } }
-
-      it {
-        should contain_package('rpcbind').with({
-          'ensure' => 'absent',
-        })
-      }
-    end
-
-    context 'with supplied string for package name' do
-      let(:facts) { { :osfamily => 'RedHat' } }
-      let(:params) { { :package_name => 'my_rpcbind' } }
-
-      it {
-        should contain_package('my_rpcbind').with({
-          'ensure' => 'installed',
-        })
-      }
-    end
-
-    context 'with supplied array for package name' do
-      let(:facts) { { :osfamily => 'RedHat' } }
-      packages = [ 'rpcbind', 'rpcbindfoo', 'rpcbindbar' ]
-      let(:params) { { :package_name => packages } }
-
-      packages.each do |pkg|
+  platforms.sort.each do |os,v|
+    context "with default values for parameters on OS #{os}" do
+      let(:facts) { v[:facts_hash] }
         it {
-          should contain_package(pkg).with({
+          should contain_package('rpcbind_package').with({
             'ensure' => 'installed',
+            'name'   => v[:package_name],
           })
         }
-      end
+
+        it {
+          should contain_service('rpcbind_service').with({
+            'ensure' => 'running',
+            'name'   => v[:service_name],
+            'enable' => true,
+            'require' => 'Package[rpcbind_package]',
+          })
+        }
     end
   end
 
-  describe 'service resource' do
-    context 'with default params on osfamily RedHat' do
-      let(:facts) { { :osfamily => 'RedHat' } }
+  describe 'with package_ensure absent' do
+    let(:facts) { platforms['el7'][:facts_hash] }
+    let(:params) { { :package_ensure => 'absent' } }
 
-      it {
-        should contain_service('rpcbind_service').with({
-          'ensure' => 'running',
-          'name'   => 'rpcbind',
-          'enable' => true,
-        })
-      }
-    end
-
-    context 'with default params on Debian' do
-      let(:facts) do
-        { :lsbdistid => 'Debian',
-          :osfamily => 'Debian',
-        }
-      end
-
-      it {
-        should contain_service('rpcbind_service').with({
-          'ensure' => 'running',
-          'name'   => 'rpcbind',
-          'enable' => true,
-        })
-      }
-    end
-
-    context 'with default params on Ubuntu 12.04' do
-      let(:facts) do
-        { :lsbdistid      => 'Ubuntu',
-          :osfamily       => 'Debian',
-          :lsbdistrelease => '12.04',
-        }
-      end
-
-      it {
-        should contain_service('rpcbind_service').with({
-          'ensure' => 'running',
-          'name'   => 'portmap',
-          'enable' => true,
-        })
-      }
-    end
-
-    context 'with default params on Ubuntu 14.04' do
-      let(:facts) do
-        { :lsbdistid      => 'Ubuntu',
-          :osfamily       => 'Debian',
-          :lsbdistrelease => '14.04',
-        }
-      end
-
-      it {
-        should contain_service('rpcbind_service').with({
-          'ensure' => 'running',
-          'name'   => 'rpcbind',
-          'enable' => true,
-        })
-      }
-    end
-
-    context 'with default params on Ubuntu 16.04' do
-      let(:facts) do
-        { :lsbdistid      => 'Ubuntu',
-          :osfamily       => 'Debian',
-          :lsbdistrelease => '16.04',
-        }
-      end
-
-      it {
-        should contain_service('rpcbind_service').with({
-          'ensure' => 'running',
-          'name'   => 'rpcbind',
-          'enable' => true,
-        })
-      }
-    end
-
-    context 'with default params on Ubuntu 18.04' do
-      let(:facts) do
-        { :lsbdistid      => 'Ubuntu',
-          :osfamily       => 'Debian',
-          :lsbdistrelease => '18.04',
-        }
-      end
-
-      it {
-        should contain_service('rpcbind_service').with({
-          'ensure' => 'running',
-          'name'   => 'rpcbind',
-          'enable' => true,
-        })
-      }
-    end
-
-    context 'with default params on Suse 10' do
-      let(:facts) do
-        { :osfamily          => 'Suse',
-          :lsbmajdistrelease => '10',
-        }
-      end
-
-      it {
-        should contain_service('rpcbind_service').with({
-          'ensure' => 'running',
-          'name'   => 'portmap',
-          'enable' => true,
-        })
-      }
-    end
-
-    context 'with default params on Suse 11' do
-      let(:facts) do
-        { :osfamily          => 'Suse',
-          :lsbmajdistrelease => '11',
-        }
-      end
-
-      it {
-        should contain_service('rpcbind_service').with({
-          'ensure' => 'running',
-          'name'   => 'rpcbind',
-          'enable' => true,
-        })
-      }
-    end
-
-    context 'with default params on Suse 12' do
-      let(:facts) do
-        { :osfamily          => 'Suse',
-          :lsbmajdistrelease => '12',
-        }
-      end
-
-      it {
-        should contain_service('rpcbind_service').with({
-          'ensure' => 'running',
-          'name'   => 'rpcbind',
-          'enable' => true,
-        })
-      }
-    end
-
-    context 'with ensure stopped' do
-      let(:facts) { { :osfamily => 'RedHat' } }
-      let(:params) { { :service_ensure => 'stopped' } }
-
-      it {
-        should contain_service('rpcbind_service').with({
-          'ensure' => 'stopped',
-          'name'   => 'rpcbind',
-          'enable' => true,
-        })
-      }
-    end
-
-    context 'with supplied string for service name' do
-      let(:facts) { { :osfamily => 'RedHat' } }
-      let(:params) { { :service_name => 'my_rpcbind' } }
-
-      it {
-        should contain_service('rpcbind_service').with({
-          'ensure' => 'running',
-          'name'   => 'my_rpcbind',
-          'enable' => true,
-        })
-      }
-    end
-
-    context 'with enable false' do
-      let(:facts) { { :osfamily => 'RedHat' } }
-      let(:params) { { :service_enable => false } }
-
-      it {
-        should contain_service('rpcbind_service').with({
-          'ensure' => 'running',
-          'name'   => 'rpcbind',
-          'enable' => false,
-        })
-      }
-    end
+    it {
+      should contain_package('rpcbind_package').with({
+        'ensure' => 'absent',
+      })
+    }
   end
+
+  describe 'with package_name specified' do
+    let(:facts) { platforms['el7'][:facts_hash] }
+    let(:params) { { :package_name => 'my_rpcbind' } }
+
+    it {
+      should contain_package('rpcbind_package').with({
+        'ensure' => 'installed',
+        'name'   => 'my_rpcbind',
+      })
+    }
+  end
+
+  describe 'with service_ensure stopped' do
+    let(:facts) { platforms['el7'][:facts_hash] }
+    let(:params) { { :service_ensure => 'stopped' } }
+
+    it {
+      should contain_service('rpcbind_service').with({
+        'ensure' => 'stopped',
+      })
+    }
+  end
+
+  describe 'with service_name specified' do
+    let(:facts) { platforms['el7'][:facts_hash] }
+    let(:params) { { :service_name => 'my_rpcbind' } }
+
+    it {
+      should contain_service('rpcbind_service').with({
+        'name' => 'my_rpcbind',
+      })
+    }
+  end
+
+  describe 'with service_enable false' do
+    let(:facts) { platforms['el7'][:facts_hash] }
+    let(:params) { { :service_enable => false } }
+
+    it {
+      should contain_service('rpcbind_service').with({
+        'enable' => false,
+      })
+    }
+  end
+
+  describe 'variable data type and content validations' do
+    let(:facts) { platforms['el7'][:facts_hash] }
+
+    validations = {
+      'boolean' => {
+        :name    => %w(service_enable),
+        :valid   => [true, false],
+        :invalid => ['string', %w(array), { 'ha' => 'sh' }, 3, 2.42, 'false'],
+        :message => 'expects a Boolean value', # Puppet 4 & 5
+      },
+      'string' => {
+        :name    => %w(package_name service_name),
+        :valid   => %w(string),
+        :invalid => [%w(array), { 'ha' => 'sh' }, 3, 2.42, false],
+        :message => 'expects a String value', # Puppet 4 & 5
+      },
+      'string_service_ensure' => {
+        :name    => %w(service_ensure),
+        :valid   => %w(running),
+        :invalid => [%w(array), { 'ha' => 'sh' }, 3, 2.42, false],
+        :message => 'expects a String value', # Puppet 4 & 5
+      },
+      'string_package_ensure' => {
+        :name    => %w(package_ensure),
+        :valid   => %w(installed),
+        :invalid => [%w(array), { 'ha' => 'sh' }, 3, 2.42, false],
+        :message => 'expects a String value', # Puppet 4 & 5
+      },
+    }
+
+    validations.sort.each do |type, var|
+      mandatory_params = {} if mandatory_params.nil?
+      var[:name].each do |var_name|
+        var[:params] = {} if var[:params].nil?
+        var[:valid].each do |valid|
+          context "when #{var_name} (#{type}) is set to valid #{valid} (as #{valid.class})" do
+            let(:facts) { [mandatory_facts, var[:facts]].reduce(:merge) } if ! var[:facts].nil?
+            let(:params) { [mandatory_params, var[:params], { :"#{var_name}" => valid, }].reduce(:merge) }
+            it { should compile }
+          end
+        end
+
+        var[:invalid].each do |invalid|
+          context "when #{var_name} (#{type}) is set to invalid #{invalid} (as #{invalid.class})" do
+            let(:params) { [mandatory_params, var[:params], { :"#{var_name}" => invalid, }].reduce(:merge) }
+            it 'should fail' do
+              expect { should contain_class(subject) }.to raise_error(Puppet::Error, /#{var[:message]}/)
+            end
+          end
+        end
+      end # var[:name].each
+    end # validations.sort.each
+  end # describe 'variable type and content validations'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,11 @@
+# This RSpec.configure block is listed twice due to a bug with
+# puppetlabs_spec_helper. https://tickets.puppetlabs.com/browse/PDK-916
+RSpec.configure do |config|
+  config.mock_with :rspec
+end
 require 'puppetlabs_spec_helper/module_spec_helper'
 
 RSpec.configure do |config|
-  config.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
   config.before :each do
     # Ensure that we don't accidentally cache facts and environment between
     # test cases.  This requires each example group to explicitly load the
@@ -10,7 +14,258 @@ RSpec.configure do |config|
     Facter.clear
     Facter.clear_messages
   end
-  config.default_facts = {
-    :environment => 'rp_env',
+end
+
+def platforms
+  {
+    'debian8' =>
+      {
+        :facts_hash => {
+          :osfamily => 'Debian',
+          :operatingsystem => 'Debian',
+          :os => {
+            'name' => 'Debian',
+            'family' => 'Debian',
+            'release' => {
+              'full'  => '8.0',
+              'major' => '8',
+              'minor' => '0'
+            },
+          },
+        },
+        :package_name => 'rpcbind',
+        :service_name => 'rpcbind',
+      },
+    'debian9' =>
+      {
+        :facts_hash => {
+          :osfamily => 'Debian',
+          :operatingsystem => 'Debian',
+          :os => {
+            'name' => 'Debian',
+            'family' => 'Debian',
+            'release' => {
+              'full'  => '9.0',
+              'major' => '9',
+              'minor' => '0'
+            },
+          },
+        },
+        :package_name => 'rpcbind',
+        :service_name => 'rpcbind',
+      },
+    'el6' =>
+      {
+        :facts_hash => {
+          :osfamily => 'RedHat',
+          :operatingsystem => 'RedHat',
+          :operatingsystemmajrelease => '6',
+          :os => {
+            'name' => 'RedHat',
+            'family' => 'RedHat',
+            'release' => {
+              'full'  => '6.5',
+              'major' => '6',
+              'minor' => '5'
+            }
+          },
+        },
+        :package_name => 'rpcbind',
+        :service_name => 'rpcbind',
+      },
+    'el7' =>
+      {
+        :facts_hash => {
+          :osfamily => 'RedHat',
+          :operatingsystem => 'RedHat',
+          :operatingsystemmajrelease => '7',
+          :os => {
+            :name => 'RedHat',
+            :family => 'RedHat',
+            :release => {
+              :full  => '7.0.1406',
+              :major => '7',
+              :minor => '0'
+            }
+          },
+        },
+        :package_name => 'rpcbind',
+        :service_name => 'rpcbind',
+      },
+    'suse11' =>
+      {
+        :facts_hash => {
+          :osfamily => 'Suse',
+          :operatingsystem => 'SLES',
+          :operatingsystemmajrelease => '11',
+          :os => {
+            'name' => 'openSUSE',
+            'family' => 'Suse',
+            'release' => {
+              'full'  => '11.1',
+              'major' => '11',
+              'minor' => '1'
+            }
+          },
+        },
+        :package_name => 'rpcbind',
+        :service_name => 'rpcbind',
+      },
+    'suse12' =>
+      {
+        :facts_hash => {
+          :osfamily => 'Suse',
+          :operatingsystem => 'SLES',
+          :operatingsystemmajrelease => '12',
+          :os => {
+            'name' => 'openSUSE',
+            'family' => 'Suse',
+            'release' => {
+              'full'  => '12.1',
+              'major' => '12',
+              'minor' => '1'
+            }
+          },
+        },
+        :package_name => 'rpcbind',
+        :service_name => 'rpcbind',
+      },
+    'ubuntu1404' =>
+      {
+        :facts_hash => {
+          :osfamily => 'Debian',
+          :operatingsystem => 'Ubuntu',
+          :os => {
+            'release' => {
+              'full'  => '14.04',
+              'major' => '14.04'
+            },
+            'name'   => 'Ubuntu',
+            'family' => 'Debian'
+          },
+        },
+        :package_name => 'rpcbind',
+        :service_name => 'rpcbind',
+      },
+    'ubuntu1604' =>
+      {
+        :facts_hash => {
+          :osfamily => 'Debian',
+          :operatingsystem => 'Ubuntu',
+          :os => {
+            'release' => {
+              'full'  => '16.04',
+              'major' => '16.04'
+            },
+            'name'   => 'Ubuntu',
+            'family' => 'Debian'
+          },
+        },
+        :package_name => 'rpcbind',
+        :service_name => 'rpcbind',
+      },
+    'ubuntu1804' =>
+      {
+        :facts_hash => {
+          :osfamily => 'Debian',
+          :operatingsystem => 'Ubuntu',
+          :os => {
+            'release' => {
+              'full'  => '18.04',
+              'major' => '18.04'
+            },
+            'name'   => 'Ubuntu',
+            'family' => 'Debian'
+          },
+        },
+        :package_name => 'rpcbind',
+        :service_name => 'rpcbind',
+      },
+  }
+end
+
+def unsupported_platforms
+  {
+    'el5' =>
+      {
+        :facts_hash => {
+          :osfamily => 'RedHat',
+          :operatingsystem => 'RedHat',
+          :operatingsystemmajrelease => '5',
+          :os => {
+            'name' => 'RedHat',
+            'family' => 'RedHat',
+            'release' => {
+              'full'  => '5.10',
+              'major' => '5',
+              'minor' => '10'
+            },
+          },
+        },
+      },
+    'debian6' =>
+      {
+        :facts_hash => {
+          :osfamily => 'Debian',
+          :operatingsystem => 'Debian',
+          :os => {
+            'name' => 'Debian',
+            'family' => 'Debian',
+            'release' => {
+              'full'  => '6.0.10',
+              'major' => '6',
+              'minor' => '0'
+            },
+          },
+        },
+      },
+    'suse10' =>
+      {
+        :facts_hash => {
+          :osfamily => 'Suse',
+          :operatingsystem => 'SLES',
+          :operatingsystemmajrelease => '10',
+          :os => {
+            'name' => 'Suse',
+            'family' => 'Suse',
+            'release' => {
+              'full'  => '10.1',
+              'major' => '10',
+              'minor' => '1'
+            }
+          },
+        },
+      },
+    'ubuntu1204' =>
+      {
+        :facts_hash => {
+          :osfamily => 'Debian',
+          :operatingsystem => 'Ubuntu',
+          :os => {
+            'release' => {
+              'full'  => '12.04',
+              'major' => '12.04'
+            },
+            'name'   => 'Ubuntu',
+            'family' => 'Debian'
+          },
+        },
+      },
+    'solaris8' =>
+      {
+        :facts_hash => {
+          :osfamily => 'Solaris',
+          :operatingsystem => 'Solaris',
+          :kernelrelease => '5.8',
+          :os => {
+            'release' => {
+              'full'  => '5.8',
+              'major' => '5',
+            },
+            'name'   => 'Solaris',
+            'family' => 'Solaris'
+          },
+        }
+      },
   }
 end


### PR DESCRIPTION
Parameter names have stayed the same, so migration should be as simple
as installing this new version.

Supported platforms have changed based on their posted end of life
(EOL).

Dropped

* Debian 6
* EL 5
* Suse 10
* Ubuntu 12.04 LTS

Added

* Debian 8
* Debian 9
* EL 7