### PR TITLE
Support EL 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,18 @@ matrix:
   - rvm: 2.4.4
     sudo: required
     services: docker
+    env: BEAKER_set="centos-8" BEAKER_PUPPET_COLLECTION=puppet5
+    bundler_args:
+    script: bundle exec rake beaker
+  - rvm: 2.5.3
+    sudo: required
+    services: docker
+    env: BEAKER_set="centos-8" BEAKER_PUPPET_COLLECTION=puppet6
+    bundler_args:
+    script: bundle exec rake beaker
+  - rvm: 2.4.4
+    sudo: required
+    services: docker
     env: BEAKER_set="debian-8" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Supports the following platforms.
 * Debian 9
 * EL 6
 * EL 7
+* EL 8
 * Suse 11
 * Suse 12
 * Suse 15

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,8 +24,8 @@ class rpcbind (
     fail('Unsupported osfamily detected. This module works with Debian, RedHat and Suse')
   }
 
-  if $facts['os']['family'] == 'RedHat' and !($facts['os']['release']['major'] in ['6','7']) {
-    fail("osfamily RedHat's os.release.major is <${::facts['os']['release']['major']}> and must be 6 or 7")
+  if $facts['os']['family'] == 'RedHat' and !($facts['os']['release']['major'] in ['6','7','8']) {
+    fail("osfamily RedHat's os.release.major is <${::facts['os']['release']['major']}> and must be 6, 7 or 8")
   } elsif $facts['os']['family'] == 'Suse' and !($facts['os']['release']['major'] in ['11','12','15']) {
     fail("osfamily Suse's os.release.major is <${::facts['os']['release']['major']}> and must be 11, 12 or 15")
   } elsif $facts['os']['name'] == 'Debian' and !($facts['os']['release']['major'] in ['8','9']) {

--- a/metadata.json
+++ b/metadata.json
@@ -25,28 +25,32 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -32,7 +32,14 @@ describe 'rpcbind class' do
 
         describe service('rpcbind') do
           it { is_expected.to be_running }
-          it { is_expected.to be_enabled }
+          # Serverspec attempts to use chkconfig for EL 8 which fails.
+          if fact('osfamily') == 'RedHat' and fact('operatingsystemrelease') =~ /^8/
+            describe command('systemctl is-enabled rpcbind') do
+              its(:exit_status) { should eq 0 }
+            end
+          else
+            it { is_expected.to be_enabled }
+          end
         end
       end
     end

--- a/spec/acceptance/nodesets/centos-8.yml
+++ b/spec/acceptance/nodesets/centos-8.yml
@@ -1,0 +1,20 @@
+HOSTS:
+  centos-8:
+    roles:
+      - agent
+    platform: el-8-x86_64
+    hypervisor: docker
+    image: centos:8
+    docker_preserve_image: true
+    docker_cmd:
+      - '/usr/sbin/init'
+    docker_image_commands:
+      - 'yum install -y tar wget cronie git iproute initscripts'
+    docker_container_name: 'rpcbind-el8'
+CONFIG:
+  log_level: debug
+  type: foss
+ssh:
+  password: root
+  auth_methods: ["password"]
+

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -74,6 +74,25 @@ def platforms
         :package_name => 'rpcbind',
         :service_name => 'rpcbind',
       },
+    'el8' =>
+      {
+        :facts_hash => {
+          :osfamily => 'RedHat',
+          :operatingsystem => 'RedHat',
+          :operatingsystemmajrelease => '8',
+          :os => {
+            :name => 'RedHat',
+            :family => 'RedHat',
+            :release => {
+              :full  => '8.0.1905',
+              :major => '8',
+              :minor => '0'
+            }
+          },
+        },
+        :package_name => 'rpcbind',
+        :service_name => 'rpcbind',
+      },
     'suse11' =>
       {
         :facts_hash => {


### PR DESCRIPTION
Add support for EL 8-based distributions. Acceptance test currently failing.

Latest git revision of beaker-docker used for EL 8 support. Fails otherwise with:
``` {"errorDetail":{"code":1,"message":"The command '/bin/sh -c yum install -y sudo openssh-server openssh-clients curl ntpdate' returned a non-zero code: 1"},"error":"The command '/bin/sh -c yum install -y sudo openssh-server openssh-clients curl ntpdate' returned a non-zero code: 1"}```

With this change it's still failing because it tried to use service which no longer exists. Logic appears to be outside the module?

```
Beaker::Host::CommandFailure:
  Host 'centos-8' exited with 127 running:
   /sbin/service sshd restart
  Last 10 lines of output were:
  	bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
  	/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
  	/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
  	/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
  	bash: /sbin/service: No such file or directory
```

I've never used beaker before. Any suggestions are welcome. Thanks!