### PR TITLE
Fix container name for EL8 acceptance test

### DIFF
--- a/spec/acceptance/nodesets/centos-8.yml
+++ b/spec/acceptance/nodesets/centos-8.yml
@@ -4,7 +4,7 @@ HOSTS:
       - agent
     platform: el-8-x86_64
     hypervisor: docker
-    image: centos:8
+    image: quay.io/centos/centos:stream8
     docker_preserve_image: true
     docker_cmd:
       - '/usr/sbin/init'


### PR DESCRIPTION
CentOS 8 is no longer supported and its repositories has been deleted. This pull requests changes the container to quay.io/centos/centos:stream8 instead.